### PR TITLE
Bump version to 0.1.1

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule ExExample.MixProject do
   def project do
     [
       app: :ex_example,
-      version: "0.1.0",
+      version: "0.1.1",
       elixir: "~> 1.17",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
## Summary
- Bump version from 0.1.0 to 0.1.1 for a bugfix release
- This release includes the execution order fix from PR #10 which corrected variable shadowing in `execution_order/1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)