### PR TITLE
Upgrade typed_struct to typedstruct

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -33,7 +33,7 @@ defmodule ExExample.MixProject do
     [
       {:cachex, "~> 4.1.1"},
       {:libgraph, "~> 0.16.0"},
-      {:typed_struct, "~> 0.3.0"},
+      {:typedstruct, "~> 0.5.0"},
       # non-runtime dependencies below
       {:credo, "~> 1.7", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 1.3", only: [:dev], runtime: false},

--- a/mix.lock
+++ b/mix.lock
@@ -17,6 +17,6 @@
   "makeup_erlang": {:hex, :makeup_erlang, "1.0.2", "03e1804074b3aa64d5fad7aa64601ed0fb395337b982d9bcf04029d68d51b6a7", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "af33ff7ef368d5893e4a267933e7744e46ce3cf1f61e2dccf53a111ed3aa3727"},
   "nimble_parsec": {:hex, :nimble_parsec, "1.4.2", "8efba0122db06df95bfaa78f791344a89352ba04baedd3849593bfce4d0dc1c6", [:mix], [], "hexpm", "4b21398942dda052b403bbe1da991ccd03a053668d147d53fb8c4e0efe09c973"},
   "sleeplocks": {:hex, :sleeplocks, "1.1.3", "96a86460cc33b435c7310dbd27ec82ca2c1f24ae38e34f8edde97f756503441a", [:rebar3], [], "hexpm", "d3b3958552e6eb16f463921e70ae7c767519ef8f5be46d7696cc1ed649421321"},
-  "typed_struct": {:hex, :typed_struct, "0.3.0", "939789e3c1dca39d7170c87f729127469d1315dcf99fee8e152bb774b17e7ff7", [:mix], [], "hexpm", "c50bd5c3a61fe4e198a8504f939be3d3c85903b382bde4865579bc23111d1b6d"},
+  "typedstruct": {:hex, :typedstruct, "0.5.4", "d1d33d58460a74f413e9c26d55e66fd633abd8ac0fb12639add9a11a60a0462a", [:make, :mix], [], "hexpm", "ffaef36d5dbaebdbf4ed07f7fb2ebd1037b2c1f757db6fb8e7bcbbfabbe608d8"},
   "unsafe": {:hex, :unsafe, "1.0.2", "23c6be12f6c1605364801f4b47007c0c159497d0446ad378b5cf05f1855c0581", [:mix], [], "hexpm", "b485231683c3ab01a9cd44cb4a79f152c6f3bb87358439c6f68791b85c2df675"},
 }


### PR DESCRIPTION
## Summary

- Replace `typed_struct ~> 0.3.0` with `typedstruct ~> 0.5.0` in mix.exs
- The `typed_struct` package was renamed to `typedstruct` — both define the same `TypedStruct` module
- Downstream projects (e.g. local-upload) that depend on `typedstruct ~> 0.5` get a `Duplicated modules` error on `mix release` because both packages are present

No code changes — the module API (`use TypedStruct`, `typedstruct do`, `field`) is identical across both packages.

## Test plan

- [x] `mix compile --warnings-as-errors` passes
- [x] `mix test` — 5 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)